### PR TITLE
Bugfix: Delegate causes incompatibilities

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -20,7 +20,7 @@
 			return array(
 				array(
 					'page' => '/backend/',
-					'delegate' => 'AdminPagePreGenerate',
+					'delegate' => 'InitaliseAdminPageHead',
 					'callback' => '__appendAssets'
 				)
 			);


### PR DESCRIPTION
You shouldn't request a page callback using the AdminPagePreGenerate delegate. This will cause problems e.g. with the Email Template Manager extension (due to the way it builds backend pages).

Actually the InitaliseAdminPageHead is suited better for this purpose anyway.
