### PR TITLE
Image URL fix

### DIFF
--- a/assets/image_index_preview.publish.js
+++ b/assets/image_index_preview.publish.js
@@ -32,7 +32,7 @@ jQuery(document).ready(function($) {
 
 			// add preview
 			$('<img />', {
-				src: this.src.replace('workspace','image/1/'+size);
+				src: this.src.replace('workspace','image/1/'+size)
 			}).prependTo(link);
 		}
 	 }


### PR DESCRIPTION
Image URLs were broken after img.onload event. They now use the src of the loaded image.
