### PR TITLE
1.4.2 - Fixes image paths on index pages (Issue #20)

### DIFF
--- a/assets/image_index_preview.publish.js
+++ b/assets/image_index_preview.publish.js
@@ -45,7 +45,7 @@ jQuery(document).ready(function($) {
 				if (link.data('path') != null) {
 					path = link.data('path');
 					filename = link.text();
-					file = path.replace(root,'').replace('/workspace/','/') + filename;
+					file = (path.replace(root,'').replace('/workspace','') + '/' + filename).substring(1);
 					full_filepath = root + path + '/' + filename;
 				}
 			}

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -13,6 +13,9 @@
 		</author>
 	</authors>
 	<releases>
+		<release version="1.4.2" date="2015-05-28" min="2.3.5" max="2.6.x">
+			- Fixes image paths on index pages (Issue #20)
+		</release>
 		<release version="1.4.1" date="2015-01-15" min="2.3.5" max="2.6.x">
 			- Compatibility with Symphony 2.6beta2 (tested in 2.3.5)
 		</release>


### PR DESCRIPTION
See https://github.com/symphonists/image_index_preview/issues/20#issuecomment-106266049 for details